### PR TITLE
Adding Tel link support

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,5 @@
+
+
 function createContextMenus() {
   chrome.contextMenus.removeAll(function() {
     const menus = [
@@ -22,10 +24,27 @@ function handleContextMenuWithKey(info, tab, key) {
 
   switch (info.menuItemId) {
     case "send-url":
-      if (info.linkText && info.linkText != info.linkUrl)
-        params['text'] = info.linkText + ': ' + info.linkUrl
-      else
-        params['text'] = info.linkUrl
+      // Check if it's a telephone link
+      // For telephone links, send just the tel: URL (Telegram auto-detects it)
+      if (info.linkText && info.linkText != info.linkUrl) {
+        params['text'] = info.linkText;
+        params['url'] = info.linkUrl;  // Send URL separately
+        }
+      // Check if it's a mailto link
+      else if (info.linkUrl.startsWith('mailto:')) {
+        const email = info.linkUrl.substring(7);
+        const displayText = info.linkText || email;
+        params['text'] = `<a href="mailto:${email}">${displayText}</a>`;
+        params['parse_mode'] = 'HTML';
+      }
+      // Regular links
+      else if (info.linkText && info.linkText != info.linkUrl) {
+        params['text'] = `<a href="${info.linkUrl}">${info.linkText}</a>`;
+        params['parse_mode'] = 'HTML';
+      }
+      else {
+        params['text'] = info.linkUrl;
+      }
       break;
     case "send-selection":
       params['text'] = info.selectionText + '\n\n' + info.pageUrl;
@@ -58,7 +77,7 @@ function handleContextMenuWithKey(info, tab, key) {
         formData.append('media', content);
         return { method: 'POST', body: formData };
       }).then(options => {
-        return window.fetch('https://teleput.textual.ru/upload', options);
+        return window.fetch(N8N_URL, options);
       })
       .catch(error => {
         console.error('Error uploading file', error);
@@ -70,7 +89,7 @@ function handleContextMenuWithKey(info, tab, key) {
           body: JSON.stringify(params),
           headers: { 'Content-Type': 'application/json' }
         };
-        return window.fetch('https://teleput.textual.ru/post', options);
+        return window.fetch(N8N_URL, options);
       });
   } else if (params.text) {
     const options = {
@@ -78,7 +97,7 @@ function handleContextMenuWithKey(info, tab, key) {
       body: JSON.stringify(params),
       headers: { 'Content-Type': 'application/json' }
     };
-    window.fetch('https://teleput.textual.ru/post', options)
+    window.fetch(N8N_URL, options)
       .then(response => {
         if (!response.ok)
           console.error('Teleput server error: ' + response.statusText);

--- a/background.js
+++ b/background.js
@@ -1,4 +1,4 @@
-
+const N8N_URL = "your n8n webhook url here";
 
 function createContextMenus() {
   chrome.contextMenus.removeAll(function() {

--- a/n8n_code.js
+++ b/n8n_code.js
@@ -1,0 +1,27 @@
+const text = $input.first().json.body.text;
+const url = $input.first().json.body.url;
+
+let messageText = text;
+
+// Check if it's a tel: link
+if (url && url.startsWith('tel:')) {
+  // Extract phone number and remove spaces/encoding
+  let phoneNumber = url.substring(4).replace(/%20/g, '').replace(/\s/g, '');
+  
+  // If it doesn't start with +, add Australian country code
+  if (!phoneNumber.startsWith('+')) {
+    // Remove leading 0 if present (Australian format)
+    if (phoneNumber.startsWith('0')) {
+      phoneNumber = phoneNumber.substring(1);
+    }
+    // Add +61 for Australia
+    phoneNumber = '+61' + phoneNumber;
+  }
+  
+  messageText = phoneNumber;
+}
+
+return {
+  chat_id: "1133749209",
+  text: messageText
+};


### PR DESCRIPTION
This method creates a way to send a tel link.

I could maybe use your existing server method by merging the tel link text creation logic into the background.js file
So this is an option - and only works with "Australian" +61 phone numbers

One would hope tel: links have the international number in them, but the one I used for testing didn't - so had to figure that out.
One could add an "default" international code in the options, that would fix this problem.

If you want me to figure that out, then reject this pull, and I will work on the extension as it is...